### PR TITLE
Fix readthedocs dependencies

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -56,9 +56,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Test building documentation with tox
-        run: tox -e docs
-
   coveralls-finish:
     name: Finish coveralls-python
     needs: tests

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,12 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
+build:
+  apt_packages:
+  - libkrb5-dev
+  - libldap2-dev
+  - libsasl2-dev
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
    version: 3.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,9 +37,6 @@ except Exception:
 # This will cause the Flask application to be created with development configs
 os.environ['DEV'] = 'true'
 
-# Workaround to skip some missing dependencies
-os.environ['DOCS'] = 'true'
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 import waiverdb  # noqa: E402
 

--- a/waiverdb/app.py
+++ b/waiverdb/app.py
@@ -45,10 +45,6 @@ def load_config(app):
         default_config_obj = 'waiverdb.config.TestingConfig'
         default_config_file = os.getcwd() + '/conf/settings.py'
         silent = True
-    elif os.getenv('DOCS') == 'true':
-        default_config_obj = 'waiverdb.config.DevelopmentConfig'
-        default_config_file = os.getcwd() + '/conf/settings.py'
-        silent = True
     else:
         default_config_obj = 'waiverdb.config.ProductionConfig'
         default_config_file = '/etc/waiverdb/settings.py'

--- a/waiverdb/auth.py
+++ b/waiverdb/auth.py
@@ -3,9 +3,7 @@
 
 import base64
 import binascii
-import os
-if not os.getenv('DOCS'):   # installing gssapi causing a problem for documentation building
-    import gssapi
+import gssapi
 from flask import current_app, Response, g
 from werkzeug.exceptions import Unauthorized, Forbidden
 


### PR DESCRIPTION
Drops building documentation since Read the Docs allows to trigger builds automatically from pull requests.

See: https://docs.readthedocs.io/en/stable/tutorial/index.html?highlight=pull%20request#trigger-a-build-from-a-pull-request

JIRA: RHELWF-8102