### PR TITLE
Migration 71b84c fix and refactoring

### DIFF
--- a/waiverdb/api_v1.py
+++ b/waiverdb/api_v1.py
@@ -23,6 +23,7 @@ from werkzeug.exceptions import (
     Unauthorized,
 )
 from sqlalchemy.sql.expression import func, and_, or_
+from typing import Dict, Any
 from waiverdb import __version__
 from waiverdb.authorization import match_testcase_permissions, verify_authorization
 from waiverdb.models import db
@@ -42,11 +43,11 @@ log = logging.getLogger(__name__)
 oidc = OpenIDConnect()
 
 
-def get_resultsdb_result(result_id):
-    response = requests_session.request('GET', '{0}/results/{1}'.format(
-        current_app.config['RESULTSDB_API_URL'], result_id),
-        headers={'Content-Type': 'application/json'},
-        timeout=60)
+def get_resultsdb_result(result_id: int) -> Dict[str, Any]:
+    response = requests_session.request(
+        'GET', f'{current_app.config["RESULTSDB_API_URL"]}/results/{result_id}',
+        headers={'Content-Type': 'application/json'}, timeout=60
+    )
     response.raise_for_status()
     return response.json()
 

--- a/waiverdb/migrations/versions/71b84ccc31bb_migrate_records_from_old_format_to_new.py
+++ b/waiverdb/migrations/versions/71b84ccc31bb_migrate_records_from_old_format_to_new.py
@@ -6,27 +6,29 @@ Create Date: 2018-02-14 12:04:34.688790
 
 """
 
-# revision identifiers, used by Alembic.
-revision = '71b84ccc31bb'
-down_revision = 'f2772c2c64a6'
+import json
+import requests
 
 from alembic import op
 # These are the "lightweight" SQL expression versions (not using metadata):
 from sqlalchemy.sql.expression import table, column, select, update
 from sqlalchemy.sql.sqltypes import Integer, Text
-
-import json
-import requests
+from typing import Tuple, Dict
 
 from waiverdb.api_v1 import get_resultsdb_result
 
 
-def convert_id_to_subject_and_testcase(result_id):
+# revision identifiers, used by Alembic.
+revision = '71b84ccc31bb'
+down_revision = 'f2772c2c64a6'
+
+
+def convert_id_to_subject_and_testcase(result_id: int) -> Tuple[Dict[str, str], str]:
     try:
         result = get_resultsdb_result(result_id)
     except requests.HTTPError as e:
         if e.response.status_code == 404:
-            raise RuntimeError('Result id %s not found in Resultsdb' % (result_id)) from e
+            raise RuntimeError(f'Result id {result_id} not found in Resultsdb') from e
         else:
             raise RuntimeError('Failed looking up result in Resultsdb') from e
     except Exception as e:
@@ -34,27 +36,25 @@ def convert_id_to_subject_and_testcase(result_id):
     if 'original_spec_nvr' in result['data']:
         subject = {'original_spec_nvr': result['data']['original_spec_nvr'][0]}
     else:
-        if result['data']['type'][0] == 'koji_build' or \
-           result['data']['type'][0] == 'bodhi_update':
-            SUBJECT_KEYS = ['item', 'type']
-            subject = dict([(k, v[0]) for k, v in result['data'].items()
-                            if k in SUBJECT_KEYS])
+        if result['data']['type'][0] in ('koji_build', 'bodhi_update'):
+            subject_keys = ['item', 'type']
+            subject = {k: v[0] for k, v in result['data'].items() if k in subject_keys}
         else:
-            raise RuntimeError('Unable to determine subject for result id %s' % (result_id))
+            raise RuntimeError(f'Unable to determine subject for result id {result_id}')
     testcase = result['testcase']['name']
-    return (subject, testcase)
+    return subject, testcase
 
 
-def upgrade():
+def upgrade() -> None:
     # Lightweight table definition for producing UPDATE queries.
     waiver_table = table('waiver',
                          column('id', type_=Integer),
                          column('result_id', type_=Integer),
                          column('subject', type_=Text),
                          column('testcase', type_=Text))
-    # Get a session asociated with the alembic upgrade operation.
+    # Get a session associated with the alembic upgrade operation.
     connection = op.get_bind()
-    rows = connection.execute(select([waiver_table.c.id, waiver_table.c.result_id]))
+    rows = connection.execute(select(waiver_table.c.id, waiver_table.c.result_id))
     for waiver_id, result_id in rows:
         subject, testcase = convert_id_to_subject_and_testcase(result_id)
         connection.execute(update(waiver_table)
@@ -62,9 +62,9 @@ def upgrade():
                            .values(subject=json.dumps(subject), testcase=testcase))
 
 
-def downgrade():
+def downgrade() -> None:
     # It shouldn't be possible to downgrade this change.
     # Because the result_id field will not be populated with data anymore.
     # If the user tries to downgrade "result_id" should be not null once again
-    # like in the old version of the schema, but the value is not longer available
+    # like in the old version of the schema, but the value is no longer available
     raise RuntimeError('Irreversible migration')


### PR DESCRIPTION
After upgrading to SQLAlchemy 2, there's a migration issue, since SQLAlchemy no longer uses a list as an argument for select. It uses positional arguments instead.