### PR TITLE
waivers/+filtered API endpoint: handle scenarios (#431)

### DIFF
--- a/waiverdb/api_v1.py
+++ b/waiverdb/api_v1.py
@@ -544,8 +544,12 @@ class FilteredWaiversResource(Resource):
             clauses.append(and_(*inner_clauses))
         query = query.filter(or_(*clauses))
         if not args.include_obsolete:
-            subquery = db.session.query(func.max(Waiver.id))\
-                .group_by(Waiver.subject_type, Waiver.subject_identifier, Waiver.testcase)
+            subquery = db.session.query(func.max(Waiver.id)).group_by(
+                Waiver.subject_type,
+                Waiver.subject_identifier,
+                Waiver.testcase,
+                Waiver.scenario
+            )
             query = query.filter(Waiver.id.in_(subquery))
         return query.all()
 


### PR DESCRIPTION
The FilteredWaiversResource method which backs this endpoint tries to find only 'current' waivers by grouping all waivers by subject_type, subject_identifier and testcase, then taking only the highest-numbered waiver from each group. This breaks if we have multiple waivers for the same subject and testcase but with different scenarios - the endpoint will only return one waiver, the one with the highest ID, and will not return the valid and current waivers for other scenarios as it should.