### PR TITLE
Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1580,13 +1580,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prometheus-client"
-version = "0.19.0"
+version = "0.20.0"
 description = "Python client for the Prometheus monitoring system."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "prometheus_client-0.19.0-py3-none-any.whl", hash = "sha256:c88b1e6ecf6b41cd8fb5731c7ae919bf66df6ec6fafa555cd6c0e16ca169ae92"},
-    {file = "prometheus_client-0.19.0.tar.gz", hash = "sha256:4585b0d1223148c27a225b10dbec5ae9bc4c81a99a3fa80774fa6209935324e1"},
+    {file = "prometheus_client-0.20.0-py3-none-any.whl", hash = "sha256:cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7"},
+    {file = "prometheus_client-0.20.0.tar.gz", hash = "sha256:287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89"},
 ]
 
 [package.extras]
@@ -2822,4 +2822,4 @@ test = ["flake8", "mock", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "f403538f87292df43738b62d63bc1c0d4445373df37f16d86929f790337c6a95"
+content-hash = "58d8a28518113666b8f3e55620d90ecdd69f383f898cb4974a44fc04393da408"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ openidc-client = "^0.6.0"
 requests-gssapi = "^1.2.3"
 
 # Monitoring
-prometheus_client = "^0.19.0"
+prometheus_client = "^0.20.0"
 
 # Messaging
 fedora-messaging = "^3.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-wheel==0.42.0
+wheel==0.43.0
 pip==23.3.2
 setuptools==69.1.1


### PR DESCRIPTION
Bump prometheus-client from 0.19.0 to 0.20.0

Bumps [prometheus-client](https://github.com/prometheus/client_python) from 0.19.0 to 0.20.0.
- [Release notes](https://github.com/prometheus/client_python/releases)
- [Commits](https://github.com/prometheus/client_python/compare/v0.19.0...v0.20.0)

---
updated-dependencies:
- dependency-name: prometheus-client dependency-type: direct:production update-type: version-update:semver-minor ...



Bump wheel from 0.42.0 to 0.43.0

Bumps [wheel](https://github.com/pypa/wheel) from 0.42.0 to 0.43.0.
- [Release notes](https://github.com/pypa/wheel/releases)
- [Changelog](https://github.com/pypa/wheel/blob/main/docs/news.rst)
- [Commits](https://github.com/pypa/wheel/compare/0.42.0...0.43.0)

---
updated-dependencies:
- dependency-name: wheel dependency-type: direct:production update-type: version-update:semver-minor ...