### PR TITLE
Fix data race when creating sessions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,6 @@ WavierDB offers a HTTP REST API.
 REST API
 ========
 
-.. autoflask:: waiverdb.app:create_app(config_obj='waiverdb.config.DevelopmentConfig',create_session=False)
+.. autoflask:: waiverdb.app:create_app(config_obj='waiverdb.config.TestingConfig')
     :undoc-static:
     :order: path

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,29 +11,33 @@ import sqlalchemy
 
 
 class DisabledMessagingConfig(config.Config):
+    SESSION_SQLALCHEMY_TABLE = "sessions-disabled-messaging"
+    DATABASE_URI = 'sqlite:///:memory:'
     MESSAGE_BUS_PUBLISH = False
     AUTH_METHOD = None
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 
 class EnabledMessagedConfig(config.Config):
+    SESSION_SQLALCHEMY_TABLE = "sessions-enabled-messaging"
+    DATABASE_URI = 'sqlite:///:memory:'
     MESSAGE_BUS_PUBLISH = True
     AUTH_METHOD = None
     SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 
-@patch("waiverdb.app.event.listen")
+@patch("waiverdb.app.sqlalchemy.event.listen")
 def test_disabled_messaging_should_not_register_events(mock_listen):
-    app.create_app(DisabledMessagingConfig, create_session=False)
+    app.create_app(DisabledMessagingConfig)
     calls = [
         c for c in mock_listen.mock_calls if c == call(ANY, ANY, app.publish_new_waiver)
     ]
     assert calls == []
 
 
-@patch("waiverdb.app.event.listen")
+@patch("waiverdb.app.sqlalchemy.event.listen")
 def test_enabled_messaging_should_register_events(mock_listen):
-    app.create_app(EnabledMessagedConfig, create_session=False)
+    app.create_app(EnabledMessagedConfig)
     calls = [
         c for c in mock_listen.mock_calls if c == call(ANY, ANY, app.publish_new_waiver)
     ]

--- a/waiverdb/manage.py
+++ b/waiverdb/manage.py
@@ -4,15 +4,11 @@ import time
 import click
 from flask.cli import FlaskGroup
 from sqlalchemy.exc import OperationalError
+from waiverdb.app import create_app
 from waiverdb.models import db
 
 
-def create_waiver_app():
-    from waiverdb.app import create_app  # noqa: F401
-    return create_app(create_session=False)
-
-
-@click.group(cls=FlaskGroup, create_app=create_waiver_app)
+@click.group(cls=FlaskGroup, create_app=create_app)
 def cli():
     pass
 


### PR DESCRIPTION
Fixes the following exception:

    Traceback (most recent call last):
    File "/venv/lib64/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
        self.dialect.do_execute(
    File "/venv/lib64/python3.12/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
        cursor.execute(statement, parameters)
    psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "pg_class_relname_nsp_index"
    DETAIL:  Key (relname, relnamespace)=(sessions_id_seq, 2200) already exists.