### PR TITLE
Migrate LDAP to new server with GSSAPI authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN set -exo pipefail \
         --nodocs \
         --disablerepo=* \
         --enablerepo=fedora,updates \
+        cyrus-sasl-gssapi \
         krb5-libs \
         openldap \
         python3 \
@@ -75,6 +76,7 @@ LABEL \
     io.k8s.display-name="WaiverDB"
 
 ENV \
+    KRB5CCNAME=FILE:/tmp/krb5cc_waiverdb \
     PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONUNBUFFERED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN set -exo pipefail \
         python3 \
     && dnf --installroot=/mnt/rootfs clean all \
     # Install uv
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && python3 -m venv /venv
+    && curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ENV \
     PIP_DEFAULT_TIMEOUT=100 \
@@ -50,12 +49,8 @@ ARG COMMIT_TIMESTAMP
 # hadolint ignore=SC1091
 RUN set -ex \
     && export PATH=/root/.cargo/bin:"$PATH" \
-    && . /venv/bin/activate \
     && uv version "1.4.0.dev$COMMIT_TIMESTAMP+git.$SHORT_COMMIT" \
-    && uv build --wheel \
-    && version=$(uv version --short) \
-    && uv pip install --no-cache dist/waiverdb-"$version"-py3*.whl \
-    && deactivate \
+    && UV_PROJECT_ENVIRONMENT=/venv uv sync --frozen --no-dev --no-editable \
     && mv /venv /mnt/rootfs \
     && mkdir -p /mnt/rootfs/app /mnt/rootfs/etc/waiverdb \
     && cp -v docker/docker-entrypoint.sh /mnt/rootfs/app/entrypoint.sh \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ down:
 	$(COMPOSE) down
 
 build:
-	$(COMPOSE) build
+	$(COMPOSE) build --build-arg COMMIT_TIMESTAMP=$$(date +%s) --build-arg SHORT_COMMIT=$$(git rev-parse --short HEAD)
 
 recreate:
 	$(COMPOSE) up -d --force-recreate

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -76,7 +76,7 @@ class TestAccessControl(object):
         r = client.post('/api/v1.0/waivers/', data=json.dumps(self.data),
                         content_type='application/json', headers=self.headers)
         res_data = json.loads(r.get_data(as_text=True))
-        assert r.status_code == 401
+        assert r.status_code == 502
         assert res_data['message'] == "Some error occurred initializing the LDAP connection."
 
     @pytest.mark.usefixtures('enable_ldap_host')

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,9 +1,9 @@
 from ldap import LDAPError
 from pytest import raises
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from waiverdb.api_v1 import permissions
 from waiverdb.authorization import match_testcase_permissions, verify_authorization
-from werkzeug.exceptions import Forbidden, Unauthorized
+from werkzeug.exceptions import BadGateway, Forbidden
 
 
 # Sample data and permissions for testing
@@ -62,7 +62,7 @@ class TestVerifyAuthorization:
 
     @patch('ldap.initialize', side_effect=LDAPError('LDAP connection error'))
     def test_ldap_connection_error(self, mock_ldap):
-        with raises(Unauthorized) as exc_info:
+        with raises(BadGateway) as exc_info:
             verify_authorization(
                 'unauthorized_user', 'test_case_1', test_permissions, ldap_host, ldap_searches
             )
@@ -108,18 +108,12 @@ class TestVerifyAuthorizationOIDCGroups:
     @patch('ldap.initialize')
     @patch('waiverdb.authorization.get_group_membership', side_effect=mock_get_group_membership)
     def test_oidc_groups_no_match_ldap_authorizes(self, mock_get_group, mock_ldap_init):
-        """OIDC groups don't match, LDAP authorizes — authorized with deprecation warning."""
-        with patch('waiverdb.authorization.log.warning') as mock_warn:
-            verify_authorization(
-                'group_user', 'test_case_1', test_permissions,
-                ldap_host, ldap_searches,
-                oidc_groups=['wrong_group'],
-            )
-            # Should have logged OIDC mismatch warning and LDAP deprecation warning
-            assert mock_warn.call_count >= 2
-            warn_messages = [call.args[0] for call in mock_warn.call_args_list]
-            assert any('falling back to LDAP' in msg for msg in warn_messages)
-            assert any('LDAP authorized' in msg for msg in warn_messages)
+        """OIDC groups don't match, LDAP authorizes — authorized."""
+        verify_authorization(
+            'group_user', 'test_case_1', test_permissions,
+            ldap_host, ldap_searches,
+            oidc_groups=['wrong_group'],
+        )
 
     @patch('ldap.initialize')
     @patch('waiverdb.authorization.get_group_membership', side_effect=mock_get_group_membership)
@@ -209,3 +203,45 @@ def test_match_testcase_permissions():
         == [permissions[1]]
     assert list(match_testcase_permissions("kernel-qe.test1", permissions)) \
         == [permissions[0]]
+
+
+class TestVerifyAuthorizationGSSAPI:
+    """Tests for GSSAPI LDAP bind support in verify_authorization."""
+
+    @patch('ldap.initialize')
+    @patch('waiverdb.authorization.get_group_membership', side_effect=mock_get_group_membership)
+    def test_gssapi_bind_called(self, mock_get_group, mock_ldap_init):
+        """When use_gssapi=True, GSSAPI credentials are initialized and SASL bind is performed."""
+        mock_con = MagicMock()
+        mock_ldap_init.return_value = mock_con
+        verify_authorization(
+            'group_user', 'test_case_1', test_permissions,
+            ldap_host, ldap_searches,
+            use_gssapi=True,
+        )
+        mock_con.sasl_gssapi_bind_s.assert_called_once()
+
+    @patch('ldap.initialize')
+    @patch('waiverdb.authorization.get_group_membership', side_effect=mock_get_group_membership)
+    def test_gssapi_not_called_by_default(self, mock_get_group, mock_ldap_init):
+        """When use_gssapi is not set, no GSSAPI bind is performed."""
+        mock_con = MagicMock()
+        mock_ldap_init.return_value = mock_con
+        verify_authorization(
+            'group_user', 'test_case_1', test_permissions,
+            ldap_host, ldap_searches,
+        )
+        mock_con.sasl_gssapi_bind_s.assert_not_called()
+
+    @patch('ldap.initialize')
+    def test_gssapi_bind_failure(self, mock_ldap_init):
+        """SASL GSSAPI bind failure raises BadGateway."""
+        mock_con = MagicMock()
+        mock_ldap_init.return_value = mock_con
+        mock_con.sasl_gssapi_bind_s.side_effect = LDAPError('GSSAPI bind failed')
+        with raises(BadGateway):
+            verify_authorization(
+                'group_user', 'test_case_1', test_permissions,
+                ldap_host, ldap_searches,
+                use_gssapi=True,
+            )

--- a/waiverdb/api_v1.py
+++ b/waiverdb/api_v1.py
@@ -111,7 +111,9 @@ def _verify_authorization(user, testcase):
         if ldap_base:
             ldap_search_string = current_app.config.get('LDAP_SEARCH_STRING', '(memberUid={user})')
             ldap_searches = [{'BASE': ldap_base, 'SEARCH_STRING': ldap_search_string}]
-    verify_authorization(user, testcase, permissions(), ldap_host, ldap_searches, oidc_groups)
+    use_gssapi = current_app.config.get('LDAP_GSSAPI', False)
+    verify_authorization(user, testcase, permissions(), ldap_host, ldap_searches, oidc_groups,
+                         use_gssapi=use_gssapi)
 
 
 def _authorization_warning_from_exception(e: Forbidden | Unauthorized, testcase: str):

--- a/waiverdb/auth.py
+++ b/waiverdb/auth.py
@@ -3,8 +3,8 @@
 
 import base64
 import binascii
+import json
 import gssapi
-from authlib.jose import jwt
 from authlib.oauth2.base import OAuth2Error
 from flask import current_app, Request, Response, session
 from werkzeug.exceptions import Unauthorized
@@ -88,9 +88,10 @@ def _oidc_session_sources():
 
         access_token = token.get("access_token", "")
         if access_token:
-            load_key = current_app.oidc.oauth.oidc.create_load_key()
-            claims = jwt.decode(access_token, load_key)
-            yield dict(claims)
+            # Token was already verified during OIDC login; just read claims.
+            payload = access_token.split(".")[1]
+            payload += "=" * (-len(payload) % 4)
+            yield json.loads(base64.urlsafe_b64decode(payload))
 
 
 def get_oidc_userinfo(field: str) -> str:

--- a/waiverdb/authorization.py
+++ b/waiverdb/authorization.py
@@ -9,7 +9,6 @@ from werkzeug.exceptions import (
     BadGateway,
     Forbidden,
     InternalServerError,
-    Unauthorized,
 )
 
 log = logging.getLogger(__name__)
@@ -30,7 +29,7 @@ def get_group_membership(ldap, user, con, ldap_search):
         raise BadGateway('The LDAP server is not reachable.')
     except ldap.LDAPError:
         log.exception('Some error occurred initializing the LDAP connection.')
-        raise Unauthorized('Some error occurred initializing the LDAP connection.')
+        raise BadGateway('Some error occurred initializing the LDAP connection.')
 
 
 def match_testcase(testcase: str, patterns: list[str]):
@@ -60,7 +59,7 @@ def _check_oidc_groups(user, testcase, oidc_groups, allowed_groups):
         return False
 
     if not oidc_groups:
-        log.warning(
+        log.debug(
             "OIDC token for user %s contains an empty groups claim; "
             "falling back to LDAP for test case %s",
             user, testcase,
@@ -70,7 +69,7 @@ def _check_oidc_groups(user, testcase, oidc_groups, allowed_groups):
     if not set(oidc_groups).isdisjoint(allowed_groups):
         return True
 
-    log.warning(
+    log.debug(
         "OIDC groups %r did not match any allowed groups %r for user %s "
         "and test case %s; falling back to LDAP",
         oidc_groups, allowed_groups, user, testcase,
@@ -78,7 +77,8 @@ def _check_oidc_groups(user, testcase, oidc_groups, allowed_groups):
     return False
 
 
-def _check_ldap_groups(user, testcase, ldap_host, ldap_searches, allowed_groups):
+def _check_ldap_groups(user, testcase, ldap_host, ldap_searches, allowed_groups,
+                       use_gssapi=False):
     """
     Check LDAP group membership.
 
@@ -91,9 +91,11 @@ def _check_ldap_groups(user, testcase, ldap_host, ldap_searches, allowed_groups)
 
     try:
         con = ldap.initialize(ldap_host)
+        if use_gssapi:
+            con.sasl_gssapi_bind_s()
     except ldap.LDAPError:
         log.exception('Some error occurred initializing the LDAP connection.')
-        raise Unauthorized('Some error occurred initializing the LDAP connection.')
+        raise BadGateway('Some error occurred initializing the LDAP connection.')
 
     group_membership = set()
     for cur_ldap_search in ldap_searches:
@@ -118,6 +120,7 @@ def verify_authorization(
     user: str, testcase: str, permissions: list[dict[str, Any]],
     ldap_host: str, ldap_searches: list[dict[str, str]],
     oidc_groups: list[str] | None = None,
+    use_gssapi: bool = False,
 ):
     allowed_groups = []
     for permission in match_testcase_permissions(testcase, permissions):
@@ -128,14 +131,8 @@ def verify_authorization(
     if _check_oidc_groups(user, testcase, oidc_groups, allowed_groups):
         return
 
-    if _check_ldap_groups(user, testcase, ldap_host, ldap_searches, allowed_groups):
-        if oidc_groups is not None:
-            log.warning(
-                "LDAP authorized user %s for test case %s. "
-                "Consider adding the appropriate groups to the user's "
-                "OIDC token to avoid LDAP dependency.",
-                user, testcase,
-            )
+    if _check_ldap_groups(user, testcase, ldap_host, ldap_searches, allowed_groups,
+                          use_gssapi=use_gssapi):
         return
 
     raise Forbidden(


### PR DESCRIPTION
Some groups are only available in LDAP, so we cannot rely solely on
OIDC token groups. Migrate to new IPA LDAP server with GSSAPI
authentication, following the same approach as product-listings-manager.

Keep existing OIDC groups check as the first path to avoid unnecessary
LDAP queries when groups are available in the token. Downgrade LDAP
fallback log messages from warnings to debug since falling back to LDAP
is now expected behavior.

Fix HTTP status codes for LDAP connection errors from 401 Unauthorized
to 502 Bad Gateway, since these are server-side failures.

JIRA: RHELWF-13972

----

Replace authlib.jose.jwt.decode + create_load_key() with simple base64
JWT payload extraction for reading OIDC access token claims. The token
was already verified during the OIDC login flow, so cryptographic
verification is unnecessary. This avoids the deprecated authlib.jose
module which breaks with newer authlib versions.

Use "uv sync --frozen --no-dev" instead of "uv pip install" in the
Dockerfile so the container installs exact versions from uv.lock.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>